### PR TITLE
Increase resource limits and runner profiles

### DIFF
--- a/charts/jobrunner/values.yaml
+++ b/charts/jobrunner/values.yaml
@@ -22,8 +22,8 @@ resources:
       cpu: 500m
       memory: 64Mi
     limits:
-      cpu: 1000m
-      memory: 128Mi
+      cpu: 2000m
+      memory: 2048Mi
   rescheduler:
     requests:
       cpu: 500m
@@ -39,11 +39,11 @@ redis:
 runners:
   basic: 2
   dispChanges: 2
-  profiles: 2
-  cirrusSearch: 0
+  profiles: 8
+  cirrusSearch: 1
 
 memory:
-  default: "400M"
+  default: "512M"
   cirrusSearchElasticaWrite: "600M"
   cirrusSearchMassIndex: "600M"
 


### PR DESCRIPTION
Currently, the jobrunner is incredibly slow, not even close to the speed it was on mardi02. Consequently, a job queue builds up, causing inconsistencies across portal services. Moreover, for caching effect its better to update quick as each change to the kg invalidates caches to the changed item and the connected items.

# MaRDI Pull Request

**Changes**:
- 
- 
-  

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased resource allocation for job runners to enhance system performance and capacity.
  * Enabled search indexing capability.
  * Improved default memory configuration for enhanced stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->