### PR TITLE
Make jobrunner faster

### DIFF
--- a/apps/production/jobrunner/values-production.yaml
+++ b/apps/production/jobrunner/values-production.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.1.19"
+      version: "0.1.18"
   values:
     image:
       repository: ghcr.io/mardi4nfdi/redis-jobrunner-production


### PR DESCRIPTION
Updated jobrunner chart version and adjusted resource allocation for profiles and cirrusSearch. Currently, the jobrunner is incredibly slow, not even close to the speed it was on mardi02. Consequently, a job queue builds up, causing inconsistencies across portal services. Moreover, for caching, it's better to update quickly, as each change to the KG invalidates the cache for the changed item and its connected items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Increased job runner capacity in the production environment
  * Expanded search infrastructure capacity to support higher query loads
  * Added default memory limits for optimized resource allocation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->