### PR TITLE
Set jobrunner count to 0

### DIFF
--- a/apps/production/jobrunner/values-production.yaml
+++ b/apps/production/jobrunner/values-production.yaml
@@ -11,10 +11,10 @@ spec:
       repository: ghcr.io/mardi4nfdi/redis-jobrunner-production
       tag: 1.46.3
     runners:
-      basic: 8
-      dispChanges: 32
-      profiles: 16
-      cirrusSearch: 32
+      basic: 0
+      dispChanges: 0
+      profiles: 0
+      cirrusSearch: 0
     memory:
       default: "512M"
       cirrusSearchElasticaWrite: "800M"


### PR DESCRIPTION
This pull request makes a configuration change to the job runner deployment, setting all runner types to zero in the `apps/production/jobrunner/values-production.yaml` file. This effectively disables all job runners in the production environment. 

Configuration changes:

* Set the number of runners for `basic`, `dispChanges`, `profiles`, and `cirrusSearch` to `0` in the `runners` section of the job runner configuration, disabling all job runner types in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted production infrastructure job runner capacity allocations for basic operations, profile management, search functionality, and dispatch change operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->