### PR TITLE
added kafka-exporter and Grafana dashboard for job queue monitoring

### DIFF
--- a/apps/base/kafka-exporter/deployment.yaml
+++ b/apps/base/kafka-exporter/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: kafka-exporter
-          image: danielqsj/kafka-exporter:latest
+          image: danielqsj/kafka-exporter:v1.7.0
           args:
             - --kafka.server=kafka-0.kafka.production.svc.cluster.local:9092
             - --kafka.server=kafka-1.kafka.production.svc.cluster.local:9092

--- a/apps/base/kafka-exporter/deployment.yaml
+++ b/apps/base/kafka-exporter/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: kafka-exporter
-          image: danielqsj/kafka-exporter:v1.7.0
+          image: danielqsj/kafka-exporter:v1.9.0
           ports:
             - name: metrics
               containerPort: 9308

--- a/apps/base/kafka-exporter/deployment.yaml
+++ b/apps/base/kafka-exporter/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-exporter
+  namespace: production
+  labels:
+    app: kafka-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-exporter
+  template:
+    metadata:
+      labels:
+        app: kafka-exporter
+    spec:
+      containers:
+        - name: kafka-exporter
+          image: danielqsj/kafka-exporter:latest
+          args:
+            - --kafka.server=kafka-0.kafka.production.svc.cluster.local:9092
+            - --kafka.server=kafka-1.kafka.production.svc.cluster.local:9092
+            - --kafka.server=kafka-2.kafka.production.svc.cluster.local:9092
+            - --group.filter=cpjobqueue-job_execute
+          ports:
+            - name: metrics
+              containerPort: 9308
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-exporter
+  namespace: production
+  labels:
+    app: kafka-exporter
+spec:
+  selector:
+    app: kafka-exporter
+  ports:
+    - name: metrics
+      port: 9308
+      targetPort: metrics

--- a/apps/base/kafka-exporter/deployment.yaml
+++ b/apps/base/kafka-exporter/deployment.yaml
@@ -17,11 +17,6 @@ spec:
       containers:
         - name: kafka-exporter
           image: danielqsj/kafka-exporter:v1.7.0
-          args:
-            - --kafka.server=kafka-0.kafka.production.svc.cluster.local:9092
-            - --kafka.server=kafka-1.kafka.production.svc.cluster.local:9092
-            - --kafka.server=kafka-2.kafka.production.svc.cluster.local:9092
-            - --group.filter=cpjobqueue-job_execute
           ports:
             - name: metrics
               containerPort: 9308

--- a/apps/base/kafka-exporter/deployment.yaml
+++ b/apps/base/kafka-exporter/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kafka-exporter
-  namespace: production
   labels:
     app: kafka-exporter
 spec:
@@ -38,7 +37,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kafka-exporter
-  namespace: production
   labels:
     app: kafka-exporter
 spec:

--- a/apps/base/kafka-exporter/kustomization.yaml
+++ b/apps/base/kafka-exporter/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - servicemonitor.yaml

--- a/apps/base/kafka-exporter/servicemonitor.yaml
+++ b/apps/base/kafka-exporter/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kafka-exporter
-  namespace: production
   labels:
     # Match the label selector used by the kube-prometheus Prometheus instance
     release: kube-prometheus

--- a/apps/base/kafka-exporter/servicemonitor.yaml
+++ b/apps/base/kafka-exporter/servicemonitor.yaml
@@ -2,9 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kafka-exporter
-  labels:
-    # Match the label selector used by the kube-prometheus Prometheus instance
-    release: kube-prometheus
 spec:
   selector:
     matchLabels:

--- a/apps/base/kafka-exporter/servicemonitor.yaml
+++ b/apps/base/kafka-exporter/servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kafka-exporter
+  namespace: production
+  labels:
+    # Match the label selector used by the kube-prometheus Prometheus instance
+    release: kube-prometheus
+spec:
+  selector:
+    matchLabels:
+      app: kafka-exporter
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics

--- a/apps/production/kafka-exporter/deployment-production-args.yaml
+++ b/apps/production/kafka-exporter/deployment-production-args.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-exporter
+spec:
+  template:
+    spec:
+      containers:
+        - name: kafka-exporter
+          args:
+            - --kafka.server=kafka-0.kafka.production.svc.cluster.local:9092
+            - --kafka.server=kafka-1.kafka.production.svc.cluster.local:9092
+            - --kafka.server=kafka-2.kafka.production.svc.cluster.local:9092
+            - --group.filter=cpjobqueue-job_execute

--- a/apps/production/kafka-exporter/kustomization.yaml
+++ b/apps/production/kafka-exporter/kustomization.yaml
@@ -5,3 +5,9 @@ namespace: production
 
 resources:
   - ../../base/kafka-exporter
+
+patches:
+  - path: deployment-production-args.yaml
+    target:
+      kind: Deployment
+      name: kafka-exporter

--- a/apps/production/kafka-exporter/kustomization.yaml
+++ b/apps/production/kafka-exporter/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: production
+
+resources:
+  - ../../base/kafka-exporter

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -34,6 +34,7 @@ resources:
   - eventgate
   - eventstreams
   - change-propagation
+  - kafka-exporter
 
 patches:
   - target:

--- a/infrastructure/grafana-dashboards/kafka-mardi-dashboard.yaml
+++ b/infrastructure/grafana-dashboards/kafka-mardi-dashboard.yaml
@@ -230,5 +230,5 @@ data:
         }
       ],
       "schemaVersion": 36,
-      "version": 1.5
+      "version": 1
     }

--- a/infrastructure/grafana-dashboards/kafka-mardi-dashboard.yaml
+++ b/infrastructure/grafana-dashboards/kafka-mardi-dashboard.yaml
@@ -1,0 +1,234 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-mardi-dashboard
+  namespace: kube-prometheus
+  labels:
+    grafana_dashboard: "1"
+data:
+  kafka-mardi-dashboard.json: |
+    {
+      "title": "MaRDI Kafka Job Queue Lag",
+      "uid": "mardi-kafka-lag",
+      "tags": ["kafka", "mardi", "jobqueue"],
+      "timezone": "browser",
+      "refresh": "30s",
+      "time": { "from": "now-3h", "to": "now" },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Total consumer group lag",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 0,
+              "custom": { "lineWidth": 2, "fillOpacity": 10 }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(kafka_consumergroup_lag{consumergroup=\"cpjobqueue-job_execute\"}) by (topic)",
+              "legendFormat": "{{topic}}",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] },
+            "tooltip": { "mode": "multi" }
+          }
+        },
+        {
+          "id": 2,
+          "title": "Total lag (all topics summed)",
+          "type": "stat",
+          "gridPos": { "x": 0, "y": 8, "w": 6, "h": 4 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10000 },
+                  { "color": "red", "value": 500000 }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(kafka_consumergroup_lag{consumergroup=\"cpjobqueue-job_execute\"})",
+              "legendFormat": "Total lag",
+              "refId": "A"
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "background" }
+        },
+        {
+          "id": 3,
+          "title": "Topics with lag > 0",
+          "type": "stat",
+          "gridPos": { "x": 6, "y": 8, "w": 6, "h": 4 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 3 },
+                  { "color": "red", "value": 6 }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "count(sum by (topic) (kafka_consumergroup_lag{consumergroup=\"cpjobqueue-job_execute\"}) > 0)",
+              "legendFormat": "Topics with lag",
+              "refId": "A"
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+        },
+        {
+          "id": 4,
+          "title": "wikibase-addUsagesForPage lag",
+          "type": "stat",
+          "gridPos": { "x": 12, "y": 8, "w": 6, "h": 4 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 50000 },
+                  { "color": "red", "value": 500000 }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(kafka_consumergroup_lag{consumergroup=\"cpjobqueue-job_execute\", topic=~\".*wikibase-addUsagesForPage.*\"})",
+              "legendFormat": "addUsagesForPage",
+              "refId": "A"
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+        },
+        {
+          "id": 5,
+          "title": "CreateProfilePages lag",
+          "type": "stat",
+          "gridPos": { "x": 18, "y": 8, "w": 6, "h": 4 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(kafka_consumergroup_lag{consumergroup=\"cpjobqueue-job_execute\", topic=~\".*CreateProfilePages.*\"})",
+              "legendFormat": "CreateProfilePages",
+              "refId": "A"
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+        },
+        {
+          "id": 6,
+          "title": "Lag per topic — current snapshot",
+          "type": "bargauge",
+          "gridPos": { "x": 0, "y": 12, "w": 24, "h": 10 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1000 },
+                  { "color": "orange", "value": 50000 },
+                  { "color": "red", "value": 500000 }
+                ]
+              },
+              "custom": { "orientation": "horizontal" }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sort_desc(sum by (topic) (kafka_consumergroup_lag{consumergroup=\"cpjobqueue-job_execute\"} > 0))",
+              "legendFormat": "{{topic}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true
+          }
+        },
+        {
+          "id": 7,
+          "title": "Retry queue lag per topic",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 22, "w": 24, "h": 7 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": { "lineWidth": 2, "fillOpacity": 8 }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(kafka_consumergroup_lag{consumergroup=\"cpjobqueue-job_execute\", topic=~\".*retry.*\"}) by (topic)",
+              "legendFormat": "{{topic}}",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] },
+            "tooltip": { "mode": "multi" }
+          }
+        },
+        {
+          "id": 8,
+          "title": "Log end offset growth (message production rate)",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 29, "w": 24, "h": 7 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": { "lineWidth": 1, "fillOpacity": 5 }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(kafka_topic_partition_current_offset{topic=~\"mardi.mediawiki.job.*\"}[5m])) by (topic)",
+              "legendFormat": "{{topic}}",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean"] },
+            "tooltip": { "mode": "multi" }
+          }
+        }
+      ],
+      "schemaVersion": 36,
+      "version": 1.5
+    }

--- a/infrastructure/grafana-dashboards/kustomization.yaml
+++ b/infrastructure/grafana-dashboards/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kafka-mardi-dashboard.yaml

--- a/infrastructure/kustomization.yaml
+++ b/infrastructure/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - mariadb
   - portainer
   - cert-manager
+  - grafana-dashboards
   #- crowdsec


### PR DESCRIPTION
# MaRDI Pull Request

## Add Kafka job queue monitoring

Adds kafka-exporter and a Grafana dashboard to make the MediaWiki job queue lag visible in the existing kube-prometheus Grafana instance.

### What this adds

**`apps/base/kafka-exporter/`** and **`apps/production/kafka-exporter/`**
- Deploys `danielqsj/kafka-exporter` pointing at the production Kafka brokers
- Filters to the `cpjobqueue-job_execute` consumer group
- Adds a `ServiceMonitor` so Prometheus scrapes it automatically (no label selector required — the Prometheus instance selects all ServiceMonitors)

**`infrastructure/grafana-dashboards/`**
- Adds a ConfigMap with `grafana_dashboard: "1"` label, which the admin-managed Grafana instance picks up automatically
- Dashboard shows: total lag per topic, stat cards for key job types, horizontal bar gauge, and retry queue panel
- Visible at https://grafana-mardi.zib.de → MaRDI Kafka Job Queue Lag



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployed Kafka metrics exporter to production with resource limits and exposed metrics port
  * Added ServiceMonitor for Prometheus scraping at 30s intervals
  * Added Grafana dashboard "MaRDI Kafka Job Queue Lag" with panels for consumer lag, topic offsets, retry topics, and production rates
  * Integrated manifests into Kustomize overlays for base and production deployments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->