### PR TITLE
Add metrics configuration to traefik-values-production.yaml

### DIFF
--- a/apps/production/traefik/traefik-values-production.yaml
+++ b/apps/production/traefik/traefik-values-production.yaml
@@ -32,7 +32,7 @@ spec:
         expose:
           default: false
         port: 9100
-        protocol: TCP    
+        protocol: TCP
     metrics:
       prometheus:
         serviceMonitor:

--- a/apps/production/traefik/traefik-values-production.yaml
+++ b/apps/production/traefik/traefik-values-production.yaml
@@ -28,6 +28,11 @@ spec:
           default: true
         exposedPort: 3568
         protocol: TCP
+      metrics:
+        expose:
+          default: false
+        port: 9100
+        protocol: TCP    
     metrics:
       prometheus:
         serviceMonitor:


### PR DESCRIPTION
Add metrics configuration for Traefik with default exposure set to false - otherwise metric ports is not created on reconcile.

# MaRDI Pull Request

**Changes**:
Once Flux reconciles the HelmRelease, it will overwrite the Service and remove the metrics port (since it's not in the Helm values). The ServiceMonitor will then have nothing to scrape. That's why this PR adds it in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added metrics exposure configuration for production monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->