### PR TITLE
changed varnish cache behaviour: add 10s timeout for anonymous backen…

### DIFF
--- a/charts/wikibase/Chart.yaml
+++ b/charts/wikibase/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: wikibase
 description: A Helm chart for Mediawiki/Wikibase
 type: application
-version: 0.1.88
+version: 0.1.89
 appVersion: "1.0.0"

--- a/charts/wikibase/templates/varnish.yaml
+++ b/charts/wikibase/templates/varnish.yaml
@@ -17,11 +17,18 @@ spec:
       vclConfig: |
         vcl 4.0;
 
-        # Backend definition pointing to MediaWiki service
+        # Backend definition pointing to MediaWiki service - FOR AUTHENTICATED USERS
         backend default {
             .host = "{{ .Release.Name }}";
             .port = "{{ .Values.apache.port }}";
             .first_byte_timeout = {{ .Values.varnish.backendFirstByteTimeout }};
+            .between_bytes_timeout = {{ .Values.varnish.backendBetweenBytesTimeout }};
+        }
+        # Backend definition pointing to MediaWiki service - FOR ANONYMOUS USERS
+        backend anon {
+            .host = "{{ .Release.Name }}";
+            .port = "{{ .Values.apache.port }}";
+            .first_byte_timeout = {{ .Values.varnish.anonBackendFirstByteTimeout }};
             .between_bytes_timeout = {{ .Values.varnish.backendBetweenBytesTimeout }};
         }
 
@@ -39,6 +46,13 @@ spec:
                 set req.http.X-Forwarded-For = client.ip;
             }
             
+            # Route anonymous users to the short-timeout backend
+            if (req.http.Authorization || req.http.Cookie ~ "([sS]ession|Token)=") {
+                set req.backend_hint = default;
+            } else {
+                set req.backend_hint = anon;
+            }
+
             # Handle PURGE requests
             if (req.method == "PURGE") {
                 if (!client.ip ~ purge) {

--- a/charts/wikibase/templates/varnish.yaml
+++ b/charts/wikibase/templates/varnish.yaml
@@ -45,9 +45,21 @@ spec:
             } else {
                 set req.http.X-Forwarded-For = client.ip;
             }
-            
-            # Route anonymous users to the short-timeout backend
-            if (req.http.Authorization || req.http.Cookie ~ "([sS]ession|Token)=") {
+
+            # Detect authenticated users once: Authorization header or MediaWiki login cookies.
+            # Cookie names are anchored per RFC 6265 ("; " separator, "=" directly after name)
+            # to avoid false positives from unrelated cookies containing similar substrings.
+            # Explicitly unset in the else branch to prevent stale values on reused request objects.
+            if (req.http.Authorization ||
+                req.http.Cookie ~ "(^|; )(my_wiki_session|my_wikiToken|my_wikiUserID|my_wikiUserName)=") {
+                set req.http.X-Is-Authenticated = "1";
+            } else {
+                unset req.http.X-Is-Authenticated;
+            }
+
+            # Route to backend: authenticated users use the default (600 s first_byte_timeout),
+            # anonymous users use anon (short first_byte_timeout defined by anonBackendFirstByteTimeout).
+            if (req.http.X-Is-Authenticated) {
                 set req.backend_hint = default;
             } else {
                 set req.backend_hint = anon;
@@ -66,12 +78,12 @@ spec:
             if (req.method == "POST") {
                 return (pass);
             }
-            
+
             # Pass requests from logged-in users
-            if (req.http.Authorization || req.http.Cookie ~ "([sS]ession|Token)=") {
+            if (req.http.X-Is-Authenticated) {
                 return (pass);
             }
-            
+
             # Normalize Accept-Encoding
             if (req.http.Accept-Encoding) {
                 if (req.http.User-Agent ~ "MSIE 6") {
@@ -86,15 +98,19 @@ spec:
             }
 
             # Block expensive uncacheable pages for anonymous users
-            if (req.http.Cookie ~ "(my_wiki_session|my_wikiToken|my_wikiUserID|my_wikiUserName)") {
-                # logged in user - allow through
-            } else {
-                if (req.url ~ "(Special:RecentChangesLinked|Special:WhatLinksHere|Special:ExportRDF|Special:Log|action=history|action=info|action=edit)") {
-                    return (synth(753, "You must be logged in to view this page"));
-                }
+            # (authenticated users have already been passed above)
+            if (req.url ~ "(Special:RecentChangesLinked|Special:WhatLinksHere|Special:ExportRDF|Special:Log|action=history|action=info|action=edit)") {
+                return (synth(753, "You must be logged in to view this page"));
             }
-            
+
             return (hash);
+        }
+
+        sub vcl_backend_fetch {
+            # X-Is-Authenticated is an internal Varnish routing flag used only for backend
+            # selection and pass decisions. Unset it here so it is never forwarded to the
+            # backend application, which has no use for it and should not rely on it.
+            unset bereq.http.X-Is-Authenticated;
         }
 
         sub vcl_backend_response {

--- a/charts/wikibase/templates/varnish.yaml
+++ b/charts/wikibase/templates/varnish.yaml
@@ -51,7 +51,7 @@ spec:
             # to avoid false positives from unrelated cookies containing similar substrings.
             # Explicitly unset in the else branch to prevent stale values on reused request objects.
             if (req.http.Authorization ||
-                req.http.Cookie ~ "(^|; )(my_wiki_session|my_wikiToken|my_wikiUserID|my_wikiUserName)=") {
+                req.http.Cookie ~ "(^|;\s*)(my_wiki_session|my_wikiToken|my_wikiUserID|my_wikiUserName)="
                 set req.http.X-Is-Authenticated = "1";
             } else {
                 unset req.http.X-Is-Authenticated;

--- a/charts/wikibase/values.yaml
+++ b/charts/wikibase/values.yaml
@@ -90,6 +90,7 @@ varnish:
   enabled: false
   fullnameOverride: "varnish"
   backendFirstByteTimeout: "600s"
+  anonBackendFirstByteTimeout: "10s"
   backendBetweenBytesTimeout: "600s"
   purgeAcl: "10.0.0.0/8"
   resources:


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Add a second Varnish backend anon with a 10-second first_byte_timeout to terminate slow requests for anonymous users, while keeping the existing 600-second timeout for authenticated users via the default backend
- Route requests in vcl_recv based on session cookies/Authorization header to select the appropriate backend, and expose the anonymous timeout as anonBackendFirstByteTimeout in values.yaml (defaulting to 10s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routes authenticated and anonymous traffic to separate backends for improved handling and caching behavior.
  * Adds a configurable timeout for anonymous-backend first-byte responses.

* **Chores**
  * Bumped chart package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->