### PR TITLE
Switch wdqa updater to internal routing

### DIFF
--- a/charts/wdqs/templates/updater-deployment.yaml
+++ b/charts/wdqs/templates/updater-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: WIKIBASE_CONCEPT_URI
           value: "https://{{ .Values.global.baseDomain }}"
         - name: WIKIBASE_HOST
-          value: "{{ .Values.global.baseDomain }}"
+          value: "{{ .Values.wikibase.host }}"
         - name: WIKIBASE_SCHEME
           value: "{{ .Values.wikibase.scheme }}"
         - name: WDQS_HOST

--- a/charts/wdqs/values.yaml
+++ b/charts/wdqs/values.yaml
@@ -43,7 +43,7 @@ frontend:
 
 wikibase:
   host: wikibase
-  scheme: https
+  scheme: http
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Problem
The `wdqs-updater` is configured to fetch entity data via the public URL "https://portal.mardi4nfdi.de".

## Proposed Change
Route the updater directly to the internal Kubernetes wikibase service.

### 1. Fix the chart template
 
`charts/wdqs/templates/updater-deployment.yaml` — change `WIKIBASE_HOST` to use the configurable `wikibase.host` value instead of `global.baseDomain`:
 
```yaml
# before
- name: WIKIBASE_HOST
  value: "{{ .Values.global.baseDomain }}"
 
# after
- name: WIKIBASE_HOST
  value: "{{ .Values.wikibase.host }}"
```
 
### 2. Update the default chart values
 
`charts/wdqs/values.yaml`:
 
```yaml
wikibase:
  host: wikibase
  scheme: http  # was: https
```