### PR TITLE
Route WDQS Updater to Internal Wikibase Service

### DIFF
--- a/apps/staging/wdqs/values-staging.yaml
+++ b/apps/staging/wdqs/values-staging.yaml
@@ -10,5 +10,7 @@ spec:
     wdqs:
       host: staging-wdqs
       opts: "-Dorg.wikidata.query.rdf.tool.rdf.RdfRepository.timeout=3600 -Dcom.bigdata.rdf.sparql.ast.eval.AST2BOpUtility.timeout=60000"
+    updater:
+      wikibaseHost: "staging-wikibase"      
     frontend:
       replicas: 1

--- a/apps/staging/wdqs/values-staging.yaml
+++ b/apps/staging/wdqs/values-staging.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.1.19"
+      version: "0.1.20"
   values:
     wdqs:
       host: staging-wdqs

--- a/charts/wdqs/Chart.yaml
+++ b/charts/wdqs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: wdqs
 description: A Helm chart for the Wikibase Query System
 type: application
-version: 0.1.19
+version: 0.1.20
 appVersion: "1.0.0"

--- a/charts/wdqs/templates/updater-deployment.yaml
+++ b/charts/wdqs/templates/updater-deployment.yaml
@@ -23,9 +23,9 @@ spec:
         - name: WIKIBASE_CONCEPT_URI
           value: "https://{{ .Values.global.baseDomain }}"
         - name: WIKIBASE_HOST
-          value: "{{ .Values.global.baseDomain }}"
+          value: "{{ .Values.updater.wikibaseHost | default .Values.global.baseDomain }}"
         - name: WIKIBASE_SCHEME
-          value: "{{ .Values.wikibase.scheme }}"
+          value: "{{ .Values.updater.wikibaseScheme | default .Values.wikibase.scheme }}"  
         - name: WDQS_HOST
           value: "{{ .Values.wdqs.host }}"
         - name: WDQS_PORT

--- a/charts/wdqs/values.yaml
+++ b/charts/wdqs/values.yaml
@@ -18,6 +18,8 @@ wdqs:
 
 updater:
   enabled: true
+  wikibaseHost: "wikibase"
+  wikibaseScheme: "http"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Problem

The `wdqs-updater` fetches entity data via the public URL (`https://portal.mardi4nfdi.de`), routing through Traefik and Varnish. Any change to public-facing auth, bot protection, or caching can inadvertently break the updater.

## Proposed Change

Route the updater directly to the internal Kubernetes wikibase service, bypassing Traefik and Varnish entirely. The change is scoped to the updater only — other templates that consume `wikibase.scheme` and `wikibase.host` (e.g. the Blazegraph statefulset) are not affected.

## Changes

### 1. Add updater-specific values to `charts/wdqs/values.yaml`

```yaml
updater:
  wikibaseHost: "wikibase"
  wikibaseScheme: "http"
```

### 2. Update `charts/wdqs/templates/updater-deployment.yaml`

```yaml
# before
- name: WIKIBASE_HOST
  value: "{{ .Values.global.baseDomain }}"
- name: WIKIBASE_SCHEME
  value: "{{ .Values.wikibase.scheme }}"

# after
- name: WIKIBASE_HOST
  value: "{{ .Values.updater.wikibaseHost | default .Values.global.baseDomain }}"
- name: WIKIBASE_SCHEME
  value: "{{ .Values.updater.wikibaseScheme | default .Values.wikibase.scheme }}"
```

### 3. Override for staging in `apps/staging/wdqs/values-staging.yaml`

The staging wikibase service is named `staging-wikibase`, so an explicit override is needed:

```yaml
updater:
  wikibaseHost: "staging-wikibase"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Wikibase host and scheme for the WDQS updater, with sensible defaults for flexible deployments.
* **Chores**
  * Bumped WDQS chart version to 0.1.20.
* **Configuration**
  * Updated staging values to set the updater host and ensure frontend replica count is explicitly defined.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaRDI4NFDI/portal-k8s/pull/71)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->