### PR TITLE
Refactor: Remove copy-static-files init-container

### DIFF
--- a/apps/production/wikibase/values-production.yaml
+++ b/apps/production/wikibase/values-production.yaml
@@ -10,7 +10,7 @@ spec:
     mediawiki:
       image:
         repository: ghcr.io/mardi4nfdi/wikibase-production
-        tag: 1.47.4
+        tag: 1.47.5
       replicas: 3
       db_server: mariadb-primary:3306
       db_primary: mariadb-primary

--- a/charts/wikibase/templates/deployment-jobrunner.yaml
+++ b/charts/wikibase/templates/deployment-jobrunner.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroup: 33 # www-data
       containers:
         - name: apache
-          image: "{{ .Values.apache.image.repository }}:{{ .Values.apache.image.tag }}"
+          image: "{{ .Values.apache.image.repository }}:{{ .Values.mediawiki.image.tag }}"
           imagePullPolicy: {{ .Values.apache.image.pullPolicy }}
           resources:
             requests:

--- a/charts/wikibase/templates/deployment.yaml
+++ b/charts/wikibase/templates/deployment.yaml
@@ -18,24 +18,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 33 # www-data
-      initContainers:
-        - name: copy-static-files
-          image: "{{ .Values.mediawiki.image.repository }}:{{ .Values.mediawiki.image.tag }}"
-          command:
-            - sh
-            - -c
-            - |
-              cp -r /var/www/html/w/skins /static/skins
-              cp -r /var/www/html/w/resources /static/resources
-              cp -r /var/www/html/w/extensions /static/extensions
-              cp -r /var/www/html/w/images_repo /static/images_repo
-              cp /var/www/html/w/robots.txt /static/robots.txt
-          volumeMounts:
-            - name: static-files
-              mountPath: /static
       containers:
         - name: apache
-          image: "{{ .Values.apache.image.repository }}:{{ .Values.apache.image.tag }}"
+          image: "{{ .Values.apache.image.repository }}:{{ .Values.mediawiki.image.tag }}"
           imagePullPolicy: {{ .Values.apache.image.pullPolicy }}
           resources:
             requests:
@@ -49,22 +34,6 @@ spec:
           env:
             - name: WIKIBASE_HOST
               value: "127.0.0.1"
-          volumeMounts:
-            - name: static-files
-              mountPath: /var/www/html/w/skins
-              subPath: skins
-            - name: static-files
-              mountPath: /var/www/html/w/resources
-              subPath: resources
-            - name: static-files
-              mountPath: /var/www/html/w/extensions
-              subPath: extensions
-            - name: static-files
-              mountPath: /var/www/html/w/images_repo
-              subPath: images_repo
-            - name: static-files
-              mountPath: /var/www/html/w/robots.txt
-              subPath: robots.txt
           startupProbe:
             httpGet:
               path: /w/api.php?action=query&meta=siteinfo&format=json
@@ -101,6 +70,4 @@ spec:
           envFrom:
             {{- include "mediawiki.envFrom" . | nindent 12 }}
       volumes:
-        - name: static-files
-          emptyDir: {}
         {{- include "mediawiki.volumes" . | nindent 8 }}

--- a/charts/wikibase/values.yaml
+++ b/charts/wikibase/values.yaml
@@ -1,6 +1,3 @@
-global:
-  baseDomain: example.com
-
 mediawiki:
   image:
     repository: ghcr.io/mardi4nfdi/wikibase-staging

--- a/charts/wikibase/values.yaml
+++ b/charts/wikibase/values.yaml
@@ -1,3 +1,6 @@
+global:
+  baseDomain: example.com
+
 mediawiki:
   image:
     repository: ghcr.io/mardi4nfdi/wikibase-staging
@@ -49,7 +52,7 @@ apache:
   image:
     repository: ghcr.io/mardi4nfdi/apache
     # uses tag from mediawiki to ensure compatibility
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   port: 80
   resources:
     requests:

--- a/charts/wikibase/values.yaml
+++ b/charts/wikibase/values.yaml
@@ -48,8 +48,8 @@ mediawiki:
 apache:
   image:
     repository: ghcr.io/mardi4nfdi/apache
-    tag: latest
-    pullPolicy: Always
+    # uses tag from mediawiki to ensure compatibility
+    pullPolicy: IfNotPresent
   port: 80
   resources:
     requests:


### PR DESCRIPTION
This PR removes the ephemerial copy-static-files init-container and its associated emptyDir volume mounts. Apache now uses the multi-stage asset-bundled image synchronized with the MediaWiki version tag. This simplifies the architecture and prepares the path for a dynamic database-driven sitemap extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified static asset delivery to rely on shared volume configuration.
  * Removed redundant init step that previously copied static files.
  * Unified the web server image reference to use the main application image tag for consistency.
  * Added a default base domain configuration entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->